### PR TITLE
only add user if not already existent, otherwise container wont restart

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -e
 
-useradd --uid $RUN_UID -m --shell /bin/bash occlient
+# only add user if not already existent, otherwise container wont restart
+if [ $(getent passwd occlient|wc -l) -eq 0 ]; then
+	useradd --uid $RUN_UID -m --shell /bin/bash occlient
+fi
 
 netrc_file="/home/occlient/.netrc"
 cat <<EOF > $netrc_file


### PR DESCRIPTION
The container fails to restart if --restart=always is set with the error message 'useradd: user 'occlient' already exists' . I've added a simple check if the user already exists and only if not, the user is created