### PR TITLE
Added -s to the owncloudcmd cli because without it logs are getting very big

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,6 +8,6 @@ fi
 
 while true
 do 
-	su - occlient -c "owncloudcmd $SELFSIGN -n --non-interactive /ocdata $OC_PROTO://$OC_SERVER$OC_URLPATH$OC_WEBDAV$OC_FILEPATH"
+	su - occlient -c "owncloudcmd $SELFSIGN -s -n --non-interactive /ocdata $OC_PROTO://$OC_SERVER$OC_URLPATH$OC_WEBDAV$OC_FILEPATH"
 	sleep $RUN_INTERVAL
 done


### PR DESCRIPTION
I had several hundred gb of log files after running for a few days. I think the '-s' option is mandatory for running the owncloudcmd cli