### PR TITLE
Create netrc without reference to port number, fixes #5

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,8 +7,9 @@ if [ $(getent passwd occlient|wc -l) -eq 0 ]; then
 fi
 
 netrc_file="/home/occlient/.netrc"
+oc_server_without_port=$(echo $OC_SERVER | sed 's/\(.*\):.*/\1/')
 cat <<EOF > $netrc_file
-machine $OC_SERVER
+machine $oc_server_without_port
 	login $OC_USER
 	password $OC_PASS
 EOF


### PR DESCRIPTION
Example fix for the netrc file creation.

Another option might be creating an OC_SERVER_PORT variable, but this seems to do the job as well